### PR TITLE
Add coverage to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ https://docs.openzeppelin.com/test-helpers/0.5/
 
 npm install --save-dev @openzeppelin/test-helpers
 
+**Coverage**
+
+Run coverage reports using the command
+
+`npx hardhat coverage`
+
+Output will be in the generated coverage directory
+
+If you are using yarn, you can run 
+
+`yarn hardhat coverage`
+
+
 
 <br />
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,5 +1,6 @@
 require("@nomiclabs/hardhat-waffle");
 require("@nomiclabs/hardhat-web3");
+require('solidity-coverage');
 
 // This is a sample Hardhat task. To learn how to create your own go to
 // https://hardhat.org/guides/create-task.html

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.4.1",
     "hardhat": "^2.4.3",
-    "web3": "^1.5.2"
+    "web3": "^1.6.0",
+    "solidity-coverage": "^0.7.16"
   }
 }


### PR DESCRIPTION
Coverage reports are important in hardhat to see the holes in the tests, what logic has not been run.